### PR TITLE
feat: Standardize title and subtitle sections across all settings pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -146,7 +146,9 @@
       "Read(//var/folders/kp/whtkks4x4_q89b46fjswsnkm0000gn/T/TemporaryItems/NSIRD_screencaptureui_u4MEcD/**)",
       "Read(//var/folders/kp/whtkks4x4_q89b46fjswsnkm0000gn/T/TemporaryItems/NSIRD_screencaptureui_At12eA/**)",
       "Bash(timeout 30 npx tsc --noEmit --skipLibCheck src/app/settings/devices/DevicesClient.tsx)",
-      "Bash(tr:*)"
+      "Bash(tr:*)",
+      "Bash(git reflog:*)",
+      "Read(//var/folders/kp/whtkks4x4_q89b46fjswsnkm0000gn/T/TemporaryItems/NSIRD_screencaptureui_XtDFHo/**)"
     ],
     "deny": [],
     "ask": []

--- a/src/app/settings/integrations/page.tsx
+++ b/src/app/settings/integrations/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Puzzle, Check, X, Settings } from "lucide-react";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
+import { SettingsLayout } from "@/components/settings/SettingsLayout";
 
 const integrations = [
   {
@@ -54,17 +55,14 @@ export default function IntegrationsSettingsPage() {
   useAuthRedirect('/settings/integrations');
   
   return (
-    <div className="p-6">
-      <div className="mb-8 hidden md:block">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-          Integrations
-        </h1>
-        <p className="text-[#616161] dark:text-[#757575]">
-          Connect blipee OS with your favorite tools and services
-        </p>
-      </div>
+    <SettingsLayout pageTitle="Integrations">
+      <header className="hidden md:block p-4 sm:p-6 border-b border-gray-200 dark:border-white/[0.05]">
+        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">Integrations</h1>
+        <p className="text-xs sm:text-sm text-[#616161] dark:text-[#757575] mt-1">Connect blipee OS with your favorite tools and services</p>
+      </header>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <main className="p-4 sm:p-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {integrations.map((integration) => (
           <motion.div
             key={integration.id}
@@ -112,7 +110,8 @@ export default function IntegrationsSettingsPage() {
             )}
           </motion.div>
         ))}
-      </div>
-    </div>
+        </div>
+      </main>
+    </SettingsLayout>
   );
 }

--- a/src/app/settings/organizations/page.tsx
+++ b/src/app/settings/organizations/page.tsx
@@ -487,17 +487,13 @@ export default function OrganizationSettingsPage() {
   };
 
   return (
-    <SettingsLayout pageTitle="Organizations">
-      <div className="p-4 sm:p-6">
-        {/* Header - Hidden on mobile */}
-        <header className="hidden md:block mb-6">
-          <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">
-            {t("title")}
-          </h1>
-          <p className="text-xs sm:text-sm text-[#616161] dark:text-[#757575] mt-1">
-            {t("subtitle")}
-          </p>
-        </header>
+    <SettingsLayout pageTitle={t('title')}>
+      <header className="hidden md:block p-4 sm:p-6 border-b border-gray-200 dark:border-white/[0.05]">
+        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">{t('title')}</h1>
+        <p className="text-xs sm:text-sm text-[#616161] dark:text-[#757575] mt-1">{t('subtitle')}</p>
+      </header>
+
+      <main className="p-4 sm:p-6">
 
         {/* Search Bar with Actions - New Design */}
         <div className="flex items-center gap-2 mb-6">
@@ -761,10 +757,9 @@ export default function OrganizationSettingsPage() {
             </div>
           )}
         </div>
-      </div>
 
-      {/* Modal */}
-      <OrganizationModal
+        {/* Modal */}
+        <OrganizationModal
         key={`org-modal-${modalMode}-${selectedOrganization?.id || "new"}`}
         isOpen={showOrgModal}
         onClose={handleModalClose}
@@ -773,6 +768,7 @@ export default function OrganizationSettingsPage() {
         data={selectedOrganization}
         supabase={supabase}
       />
+      </main>
     </SettingsLayout>
   );
 }

--- a/src/app/settings/sustainability/page.tsx
+++ b/src/app/settings/sustainability/page.tsx
@@ -31,6 +31,7 @@ import { useTranslations } from '@/providers/LanguageProvider';
 import toast from 'react-hot-toast';
 import DataEntryModal from '@/components/sustainability/DataEntryModal';
 import SiteMetricsManager from '@/components/sustainability/SiteMetricsManager';
+import { SettingsLayout } from '@/components/settings/SettingsLayout';
 
 const scopeIcons = {
   scope_1: Factory,
@@ -181,21 +182,19 @@ export default function SustainabilityMetricsPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-7xl">
-      <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="mb-8"
-      >
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
-              Sustainability Metrics
-            </h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-              Manage and track your organization's sustainability metrics and data collection
-            </p>
-          </div>
+    <SettingsLayout pageTitle="Sustainability Metrics">
+      <header className="hidden md:block p-4 sm:p-6 border-b border-gray-200 dark:border-white/[0.05]">
+        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">Sustainability Metrics</h1>
+        <p className="text-xs sm:text-sm text-[#616161] dark:text-[#757575] mt-1">Manage and track your organization's sustainability metrics and data collection</p>
+      </header>
+
+      <main className="p-4 sm:p-6">
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8"
+        >
+          <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
             {sites.length === 0 && (
               <button
@@ -500,6 +499,7 @@ export default function SustainabilityMetricsPage() {
         sites={sites}
         onDataSaved={fetchData}
       />
-    </div>
+      </main>
+    </SettingsLayout>
   );
 }

--- a/src/app/settings/users/UsersClient.tsx
+++ b/src/app/settings/users/UsersClient.tsx
@@ -444,7 +444,7 @@ export default function UsersClient({ initialUsers, organizations, userRole }: U
   };
 
   return (
-    <SettingsLayout pageTitle="Users">
+    <SettingsLayout pageTitle={t('title')}>
       <header className="hidden md:block p-4 sm:p-6 border-b border-gray-200 dark:border-white/[0.05]">
         <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white">{t('title')}</h1>
         <p className="text-xs sm:text-sm text-[#616161] dark:text-[#757575] mt-1">{t('subtitle')}</p>


### PR DESCRIPTION
## Summary
- Applied consistent header structure to all settings pages
- Added SettingsLayout wrapper to Integrations and Sustainability pages
- Fixed syntax error in Organizations page

## Changes Made
- Standardized header with border-bottom and proper padding
- Updated title styling to `text-xl sm:text-2xl font-semibold`
- Updated subtitle styling to `text-xs sm:text-sm` with consistent colors
- Wrapped main content in `<main>` tags with proper padding
- All settings pages now match the Sites page layout

## Test Plan
- [x] Verified all settings pages render correctly
- [x] Confirmed consistent title/subtitle styling
- [x] Fixed syntax error in Organizations page
- [x] Tested responsive behavior on mobile and desktop

🤖 Generated with [Claude Code](https://claude.ai/code)